### PR TITLE
Use HTTPS to pull from rubygems.org

### DIFF
--- a/calendar/Gemfile
+++ b/calendar/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'google-api-client', '>= 0.6'
 gem 'sinatra', '>= 1.3'


### PR DESCRIPTION
This corrects the warning when running `bundle install`

```
The source :rubygems is deprecated because HTTP requests are insecure. 
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
