### PR TITLE
Changed source to 'https://rubygems.org'

### DIFF
--- a/adsense/Gemfile
+++ b/adsense/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'google-api-client', '>= 0.7'


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure.
