### PR TITLE
Source :rubygems is deprecated

### DIFF
--- a/adexchangeseller/Gemfile
+++ b/adexchangeseller/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'google-api-client', '>= 0.8'

--- a/drive/Gemfile
+++ b/drive/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'google-api-client', '>= 0.8'
 gem 'launchy', '>= 2.1.1'

--- a/googleplus/Gemfile
+++ b/googleplus/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'google-api-client', '>= 0.8'
 gem 'omniauth', '>= 1.1.1'

--- a/prediction/Gemfile
+++ b/prediction/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'google-api-client', '>= 0.8'
 gem 'sinatra', '>= 1.3'

--- a/service_account/Gemfile
+++ b/service_account/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'google-api-client', '>= 0.8'


### PR DESCRIPTION
> The `source :rubygems` is deprecated because HTTP requests are insecure.
Please change your source to `https://rubygems.org` if possible, or `http://rubygems.org` if not.